### PR TITLE
[enhancement] store balances at block heights - implementation

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 test_helpers.workspace = true
 tokio.workspace = true
+tokio-retry.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde_json.workspace = true

--- a/chain/src/config.rs
+++ b/chain/src/config.rs
@@ -23,8 +23,16 @@ pub struct AppConfig {
     #[clap(long, env)]
     pub database_url: String,
 
-    #[clap(long, env)]
+    #[clap(
+        long,
+        env,
+        default_value = "100",
+        help = "Time between retry attempts in milliseconds"
+    )]
     pub initial_query_retry_time: u64,
+
+    #[clap(long, env, default_value = "5")]
+    pub initial_query_retry_attempts: usize,
 
     #[command(flatten)]
     pub verbosity: Verbosity<InfoLevel>,

--- a/chain/src/main.rs
+++ b/chain/src/main.rs
@@ -160,7 +160,7 @@ async fn crawling_fn(
 
     let addresses = block.addresses_with_balance_change(native_token);
     let balances =
-        namada_service::query_balance(&client, &addresses, Some(block_height))
+        namada_service::query_balance(&client, &addresses, block_height)
             .await
             .into_rpc_error()?;
     tracing::info!("Updating balance for {} addresses...", addresses.len());
@@ -239,7 +239,7 @@ async fn crawling_fn(
                     ibc_tokens,
                 )?;
 
-                repository::balance::insert_balance(
+                repository::balance::insert_balance_in_chunks(
                     transaction_conn,
                     balances,
                 )?;
@@ -318,7 +318,7 @@ async fn initial_query(
 
     let tokens = query_tokens(client).await.into_rpc_error()?;
 
-    let balances = query_all_balances(client, Some(block_height))
+    let balances = query_all_balances(client, block_height)
         .await
         .into_rpc_error()?;
 

--- a/chain/src/main.rs
+++ b/chain/src/main.rs
@@ -159,9 +159,10 @@ async fn crawling_fn(
     let ibc_tokens = block.ibc_tokens().into_iter().map(Token::Ibc).collect();
 
     let addresses = block.addresses_with_balance_change(native_token);
-    let balances = namada_service::query_balance(&client, &addresses)
-        .await
-        .into_rpc_error()?;
+    let balances =
+        namada_service::query_balance(&client, &addresses, Some(block_height))
+            .await
+            .into_rpc_error()?;
     tracing::info!("Updating balance for {} addresses...", addresses.len());
 
     let next_governance_proposal_id =
@@ -317,7 +318,9 @@ async fn initial_query(
 
     let tokens = query_tokens(client).await.into_rpc_error()?;
 
-    let balances = query_all_balances(client).await.into_rpc_error()?;
+    let balances = query_all_balances(client, Some(block_height))
+        .await
+        .into_rpc_error()?;
 
     tracing::info!("Querying validators set...");
     let pipeline_length = namada_service::query_pipeline_length(client)

--- a/chain/src/main.rs
+++ b/chain/src/main.rs
@@ -114,22 +114,26 @@ async fn crawling_fn(
         let timestamp = Utc::now().naive_utc();
         update_crawler_timestamp(&conn, timestamp).await?;
 
-        tracing::warn!("Block {} was not processed, retry...", block_height);
+        tracing::trace!(
+            block = block_height,
+            "Block does not exist yet, waiting...",
+        );
 
         return Err(MainError::NoAction);
     }
 
-    tracing::info!("Query block...");
+    tracing::debug!(block = block_height, "Query block...");
     let tm_block_response =
         tendermint_service::query_raw_block_at_height(&client, block_height)
             .await
             .into_rpc_error()?;
-    tracing::info!(
+    tracing::debug!(
+        block = block_height,
         "Raw block contains {} txs...",
         tm_block_response.block.data.len()
     );
 
-    tracing::info!("Query block results...");
+    tracing::debug!(block = block_height, "Query block results...");
     let tm_block_results_response =
         tendermint_service::query_raw_block_results_at_height(
             &client,
@@ -139,13 +143,13 @@ async fn crawling_fn(
         .into_rpc_error()?;
     let block_results = BlockResult::from(tm_block_results_response);
 
-    tracing::info!("Query epoch...");
+    tracing::debug!(block = block_height, "Query epoch...");
     let epoch =
         namada_service::get_epoch_at_block_height(&client, block_height)
             .await
             .into_rpc_error()?;
 
-    tracing::info!("Query first block in epoch...");
+    tracing::debug!(block = block_height, "Query first block in epoch...");
     let first_block_in_epoch =
         namada_service::get_first_block_in_epoch(&client)
             .await
@@ -158,20 +162,34 @@ async fn crawling_fn(
         epoch,
         block_height,
     );
-    tracing::info!("Deserialized {} txs...", block.transactions.len());
+    tracing::debug!(
+        block = block_height,
+        txs = block.transactions.len(),
+        "Deserialized {} txs...",
+        block.transactions.len()
+    );
 
     let native_token = namada_service::get_native_token(&client)
         .await
         .into_rpc_error()?;
 
-    let ibc_tokens = block.ibc_tokens().into_iter().map(Token::Ibc).collect();
+    let ibc_tokens = block
+        .ibc_tokens()
+        .into_iter()
+        .map(Token::Ibc)
+        .collect::<Vec<Token>>();
 
     let addresses = block.addresses_with_balance_change(native_token);
+
     let balances =
         namada_service::query_balance(&client, &addresses, block_height)
             .await
             .into_rpc_error()?;
-    tracing::info!("Updating balance for {} addresses...", addresses.len());
+    tracing::debug!(
+        block = block_height,
+        "Updating balance for {} addresses...",
+        addresses.len()
+    );
 
     let next_governance_proposal_id =
         namada_service::query_next_governance_id(&client, block_height)
@@ -179,7 +197,11 @@ async fn crawling_fn(
             .into_rpc_error()?;
 
     let proposals = block.governance_proposal(next_governance_proposal_id);
-    tracing::info!("Creating {} governance proposals...", proposals.len());
+    tracing::debug!(
+        block = block_height,
+        "Creating {} governance proposals...",
+        proposals.len()
+    );
 
     let proposals_with_tally =
         namada_service::query_tallies(&client, proposals)
@@ -187,7 +209,11 @@ async fn crawling_fn(
             .into_rpc_error()?;
 
     let proposals_votes = block.governance_votes();
-    tracing::info!("Creating {} governance votes...", proposals_votes.len());
+    tracing::debug!(
+        block = block_height,
+        "Creating {} governance votes...",
+        proposals_votes.len()
+    );
 
     let validators = block.validators();
     let validator_set = ValidatorSet {
@@ -197,7 +223,11 @@ async fn crawling_fn(
 
     let addresses = block.bond_addresses();
     let bonds = query_bonds(&client, addresses).await.into_rpc_error()?;
-    tracing::info!("Updating bonds for {} addresses", bonds.len());
+    tracing::debug!(
+        block = block_height,
+        "Updating bonds for {} addresses",
+        bonds.len()
+    );
 
     let bonds_updates = bonds
         .iter()
@@ -215,12 +245,17 @@ async fn crawling_fn(
     let unbonds = namada_service::query_unbonds(&client, addresses)
         .await
         .into_rpc_error()?;
-    tracing::info!("Updating unbonds for {} addresses", unbonds.len());
+    tracing::debug!(
+        block = block_height,
+        "Updating unbonds for {} addresses",
+        unbonds.len()
+    );
 
     let withdraw_addreses = block.withdraw_addresses();
 
     let revealed_pks = block.revealed_pks();
-    tracing::info!(
+    tracing::debug!(
+        block = block_height,
         "Updating revealed pks for {} addresses",
         revealed_pks.len()
     );
@@ -237,6 +272,24 @@ async fn crawling_fn(
         first_block_in_epoch,
         timestamp: timestamp_in_sec,
     };
+
+    tracing::info!(
+        txs = block.transactions.len(),
+        ibc_tokens = ibc_tokens.len(),
+        balance_changes = balances.len(),
+        proposals = proposals_with_tally.len(),
+        votes = proposals_votes.len(),
+        validators = validators.len(),
+        bonds = bonds_updates.len(),
+        unbonds = unbonds.len(),
+        withdraws = withdraw_addreses.len(),
+        claimed_rewards = reward_claimers.len(),
+        revealed_pks = revealed_pks.len(),
+        epoch = epoch,
+        first_block_in_epoch = first_block_in_epoch,
+        block = block_height,
+        "Queried block successfully",
+    );
 
     conn.interact(move |conn| {
         conn.build_transaction()
@@ -307,7 +360,11 @@ async fn crawling_fn(
     .context_db_interact_error()
     .into_db_error()?
     .context("Commit block db transaction error")
-    .into_db_error()
+    .into_db_error()?;
+
+    tracing::info!(block = block_height, "Inserted block into database",);
+
+    Ok(())
 }
 
 async fn initial_query(
@@ -326,7 +383,7 @@ async fn try_initial_query(
     client: &HttpClient,
     conn: &Object,
 ) -> Result<(), MainError> {
-    tracing::info!("Querying initial data...");
+    tracing::debug!("Querying initial data...");
     let block_height =
         query_last_block_height(client).await.into_rpc_error()?;
     let epoch = namada_service::get_epoch_at_block_height(client, block_height)
@@ -345,7 +402,7 @@ async fn try_initial_query(
         .await
         .into_rpc_error()?;
 
-    tracing::info!("Querying validators set...");
+    tracing::debug!(block = block_height, "Querying validators set...");
     let pipeline_length = namada_service::query_pipeline_length(client)
         .await
         .into_rpc_error()?;
@@ -358,12 +415,12 @@ async fn try_initial_query(
     .await
     .into_rpc_error()?;
 
-    tracing::info!("Querying bonds and unbonds...");
+    tracing::debug!(block = block_height, "Querying bonds and unbonds...",);
     let (bonds, unbonds) = query_all_bonds_and_unbonds(client, None, None)
         .await
         .into_rpc_error()?;
 
-    tracing::info!("Querying proposals...");
+    tracing::debug!(block = block_height, "Querying proposals...");
     let proposals = query_all_proposals(client).await.into_rpc_error()?;
     let proposals_with_tally =
         namada_service::query_tallies(client, proposals.clone())
@@ -386,7 +443,7 @@ async fn try_initial_query(
         timestamp,
     };
 
-    tracing::info!("Inserting initial data... ");
+    tracing::info!(block = block_height, "Inserting initial data...");
 
     conn.interact(move |conn| {
         conn.build_transaction()
@@ -394,6 +451,11 @@ async fn try_initial_query(
             .run(|transaction_conn| {
                 repository::balance::insert_tokens(transaction_conn, tokens)?;
 
+                tracing::debug!(
+                    block = block_height,
+                    "Inserting {} balances...",
+                    balances.len()
+                );
                 repository::balance::insert_balance_in_chunks(
                     transaction_conn,
                     balances,
@@ -435,8 +497,6 @@ async fn can_process(
     block_height: u32,
     client: Arc<HttpClient>,
 ) -> Result<bool, MainError> {
-    tracing::info!("Attempting to process block: {}...", block_height);
-
     let last_block_height = namada_service::query_last_block_height(&client)
         .await
         .map_err(|e| {

--- a/chain/src/services/utils.rs
+++ b/chain/src/services/utils.rs
@@ -3,19 +3,28 @@ use namada_sdk::queries::RPC;
 use namada_sdk::storage::{self, PrefixValue};
 use tendermint_rpc::HttpClient;
 
+use shared::block::BlockHeight;
+
 /// Query a range of storage values with a matching prefix and decode them with
 /// [`BorshDeserialize`]. Returns an iterator of the storage keys paired with
 /// their associated values.
 pub async fn query_storage_prefix<T>(
     client: &HttpClient,
     key: &storage::Key,
+    height: Option<BlockHeight>,
 ) -> anyhow::Result<Option<impl Iterator<Item = (storage::Key, T)>>>
 where
     T: BorshDeserialize,
 {
     let values = RPC
         .shell()
-        .storage_prefix(client, None, None, false, key)
+        .storage_prefix(
+            client,
+            None,
+            height.map(super::namada::to_block_height),
+            false,
+            key,
+        )
         .await?;
 
     let decode = |PrefixValue { key, value }: PrefixValue| {

--- a/orm/migrations/2024-04-18-102935_init_balances/down.sql
+++ b/orm/migrations/2024-04-18-102935_init_balances/down.sql
@@ -1,3 +1,5 @@
 -- This file should undo anything in `up.sql`
 
-DROP TABLE IF EXISTS balances;
+DROP VIEW IF EXISTS balances;
+
+DROP TABLE IF EXISTS balance_changes;

--- a/orm/migrations/2024-04-18-102935_init_balances/up.sql
+++ b/orm/migrations/2024-04-18-102935_init_balances/up.sql
@@ -1,13 +1,35 @@
 -- Your SQL goes here
 
-CREATE TABLE balances (
+CREATE TABLE balance_changes (
   id SERIAL PRIMARY KEY,
+  height INTEGER NOT NULL,
   owner VARCHAR NOT NULL,
   token VARCHAR(64) NOT NULL,
   raw_amount NUMERIC(78, 0) NOT NULL,
   CONSTRAINT fk_balances_token FOREIGN KEY(token) REFERENCES token(address) ON DELETE CASCADE
 );
 
-ALTER TABLE balances ADD UNIQUE (owner, token);
+ALTER TABLE balance_changes ADD UNIQUE (owner, token, height);
 
-CREATE INDEX index_balances_owner ON balances (owner, token);
+CREATE INDEX index_balance_changes_owner_token_height ON balance_changes (owner, token, height);
+
+CREATE VIEW balances AS
+SELECT
+    bc.id,
+    bc.owner,
+    bc.token,
+    bc.raw_amount
+FROM
+    balance_changes bc
+    JOIN (
+        SELECT
+            owner,
+            token,
+            MAX(height) AS max_height
+        FROM
+            balance_changes
+        GROUP BY
+            owner,
+            token) max_heights ON bc.owner = max_heights.owner
+    AND bc.token = max_heights.token
+    AND bc.height = max_heights.max_height;

--- a/orm/src/balances.rs
+++ b/orm/src/balances.rs
@@ -5,20 +5,31 @@ use diesel::{Insertable, Queryable, Selectable};
 use shared::balance::Balance;
 use shared::token::Token;
 
-use crate::schema::balances;
+use crate::schema::balance_changes;
+use crate::views::balances;
 
 #[derive(Insertable, Clone, Queryable, Selectable, Debug)]
+#[diesel(table_name = balance_changes)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BalanceChangesInsertDb {
+    pub owner: String,
+    pub token: String,
+    pub raw_amount: BigDecimal,
+    pub height: i32,
+}
+
+pub type BalanceChangeDb = BalanceChangesInsertDb;
+
+#[derive(Clone, Queryable, Selectable, Debug)]
 #[diesel(table_name = balances)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct BalancesInsertDb {
+pub struct BalanceDb {
     pub owner: String,
     pub token: String,
     pub raw_amount: BigDecimal,
 }
 
-pub type BalanceDb = BalancesInsertDb;
-
-impl BalancesInsertDb {
+impl BalanceChangesInsertDb {
     pub fn from_balance(balance: Balance) -> Self {
         let token = match balance.token {
             Token::Native(token) => token.to_string(),
@@ -30,6 +41,7 @@ impl BalancesInsertDb {
             token,
             raw_amount: BigDecimal::from_str(&balance.amount.to_string())
                 .expect("Invalid amount"),
+            height: balance.height as i32,
         }
     }
 }

--- a/orm/src/lib.rs
+++ b/orm/src/lib.rs
@@ -15,3 +15,4 @@ pub mod token;
 pub mod transactions;
 pub mod unbond;
 pub mod validators;
+pub mod views;

--- a/orm/src/schema.rs
+++ b/orm/src/schema.rs
@@ -75,12 +75,13 @@ pub mod sql_types {
 }
 
 diesel::table! {
-    balances (id) {
+    balance_changes (id) {
         id -> Int4,
         owner -> Varchar,
         #[max_length = 64]
         token -> Varchar,
         raw_amount -> Numeric,
+        height -> Int4,
     }
 }
 
@@ -278,7 +279,7 @@ diesel::table! {
     }
 }
 
-diesel::joinable!(balances -> token (token));
+diesel::joinable!(balance_changes -> token (token));
 diesel::joinable!(bonds -> validators (validator_id));
 diesel::joinable!(governance_votes -> governance_proposals (proposal_id));
 diesel::joinable!(ibc_token -> token (address));
@@ -287,7 +288,7 @@ diesel::joinable!(pos_rewards -> validators (validator_id));
 diesel::joinable!(unbonds -> validators (validator_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
-    balances,
+    balance_changes,
     bonds,
     chain_parameters,
     crawler_state,

--- a/orm/src/views.rs
+++ b/orm/src/views.rs
@@ -1,0 +1,9 @@
+// Manually create schema for views - see also https://github.com/diesel-rs/diesel/issues/1482
+diesel::table! {
+    balances (id) {
+        id -> Int4,
+        owner -> Varchar,
+        token -> Varchar,
+        raw_amount -> Numeric,
+    }
+}

--- a/seeder/src/main.rs
+++ b/seeder/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use clap::Parser;
 use clap_verbosity_flag::LevelFilter;
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, SelectableHelper};
-use orm::balances::BalancesInsertDb;
+use orm::balances::BalanceChangesInsertDb;
 use orm::bond::BondInsertDb;
 use orm::governance_proposal::{
     GovernanceProposalInsertDb, GovernanceProposalUpdateStatusDb,
@@ -10,8 +10,8 @@ use orm::governance_proposal::{
 use orm::governance_votes::GovernanceProposalVoteInsertDb;
 use orm::pos_rewards::PosRewardInsertDb;
 use orm::schema::{
-    balances, bonds, governance_proposals, governance_votes, pos_rewards,
-    unbonds, validators,
+    balance_changes, bonds, governance_proposals, governance_votes,
+    pos_rewards, unbonds, validators,
 };
 use orm::unbond::UnbondInsertDb;
 use orm::validators::{ValidatorDb, ValidatorInsertDb};
@@ -138,7 +138,7 @@ async fn main() -> anyhow::Result<(), MainError> {
                     .execute(transaction_conn)
                     .context("Failed to remove all validators")?;
 
-                diesel::delete(balances::table)
+                diesel::delete(balance_changes::table)
                     .execute(transaction_conn)
                     .context("Failed to remove all validators")?;
 
@@ -201,12 +201,12 @@ async fn main() -> anyhow::Result<(), MainError> {
                     .execute(transaction_conn)
                     .context("Failed to insert pos rewards in db")?;
 
-                diesel::insert_into(balances::table)
-                    .values::<&Vec<BalancesInsertDb>>(
+                diesel::insert_into(balance_changes::table)
+                    .values::<&Vec<BalanceChangesInsertDb>>(
                         &balances
                             .into_iter()
                             .map(|balance| {
-                                BalancesInsertDb::from_balance(balance)
+                                BalanceChangesInsertDb::from_balance(balance)
                             })
                             .collect::<Vec<_>>(),
                     )

--- a/shared/src/balance.rs
+++ b/shared/src/balance.rs
@@ -82,6 +82,7 @@ pub struct Balance {
     pub owner: Id,
     pub token: Token,
     pub amount: Amount,
+    pub height: u32,
 }
 
 pub type Balances = Vec<Balance>;
@@ -97,6 +98,7 @@ impl Balance {
             owner: Id::Account(address.to_string()),
             token: Token::Native(Id::Account(token_address.to_string())),
             amount: Amount::fake(),
+            height: (0..10000).fake::<u32>(),
         }
     }
 
@@ -108,6 +110,7 @@ impl Balance {
             owner: Id::Account(address.to_string()),
             token,
             amount: Amount::fake(),
+            height: (0..10000).fake::<u32>(),
         }
     }
 }

--- a/webserver/src/repository/balance.rs
+++ b/webserver/src/repository/balance.rs
@@ -1,7 +1,7 @@
 use axum::async_trait;
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, SelectableHelper};
 use orm::balances::BalanceDb;
-use orm::schema::balances;
+use orm::views::balances;
 
 use crate::appstate::AppState;
 


### PR DESCRIPTION
Pushing this as draft, in order to show my proposed changes here. This cannot be merged until the corresponding feature is merged in the SDK: https://github.com/anoma/namada/pull/3530. After that's done, I'll come back here and update this to use the upstream SDK and not my fork.

This implements https://github.com/anoma/namada-indexer/issues/77.

Example of the `balance_changes` table:
![image](https://github.com/user-attachments/assets/cf5ae18a-aac9-4a1b-a973-0f62558f2730)

And corresponding `balances` view (which maintains the previous behavior of the `balances` table):
![image](https://github.com/user-attachments/assets/ea41f6cf-0ba3-46f6-acfa-e60aefdcea49)

After a transaction occurs which updates the balance (note the `id` changes in the returned row in the `balances` view to reflect which balance is now the latest one):
![image](https://github.com/user-attachments/assets/eb625427-aea0-46d9-8dc5-fcd48268fe4c)
