### PR TITLE
add ca-certificates to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG PACKAGE
 RUN cargo build --release --bin ${PACKAGE}
 
 FROM debian:bookworm-slim AS runtime
-RUN apt-get update && apt-get install -y libpq5
+RUN apt-get update && apt-get install -y libpq5 ca-certificates
 WORKDIR /app
 ARG PACKAGE
 COPY --from=builder /app/target/release/${PACKAGE} ./


### PR DESCRIPTION
without this, the modules are not able to connect HTTPS RPC end-points