### PR TITLE
chore: update namada to v0.44.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,18 +40,18 @@ axum-extra = { version = "0.9.3", features = ["query"] }
 chrono = { version = "0.4.30", features = ["serde"] }
 async-trait = "0.1.73"
 anyhow = "1.0.75"
-namada_core = { git = "https://github.com/anoma/namada", rev = "4343dce6d720df99a49f143fa02e7e2bbccc236f" }
-namada_sdk = { git = "https://github.com/anoma/namada", rev = "4343dce6d720df99a49f143fa02e7e2bbccc236f", default-features = false, features = ["std", "async-send", "download-params"] }
-namada_tx = { git = "https://github.com/anoma/namada", rev = "4343dce6d720df99a49f143fa02e7e2bbccc236f" }
-namada_governance = { git = "https://github.com/anoma/namada", rev = "4343dce6d720df99a49f143fa02e7e2bbccc236f" }
-namada_ibc = { git = "https://github.com/anoma/namada", rev = "4343dce6d720df99a49f143fa02e7e2bbccc236f" }
-namada_token = { git = "https://github.com/anoma/namada", rev = "4343dce6d720df99a49f143fa02e7e2bbccc236f" }
-namada_parameters = { git = "https://github.com/anoma/namada", rev = "4343dce6d720df99a49f143fa02e7e2bbccc236f" }
-namada_proof_of_stake = { git = "https://github.com/anoma/namada", rev = "4343dce6d720df99a49f143fa02e7e2bbccc236f" }
-tendermint = "0.37.0"
-tendermint-config = "0.37.0"
-tendermint-rpc = { version = "0.37.0", features = ["http-client"] }
-tendermint-proto = "0.37.0"
+namada_core = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
+namada_sdk = { git = "https://github.com/anoma/namada", tag = "v0.44.0", default-features = false, features = ["std", "async-send", "download-params"] }
+namada_tx = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
+namada_governance = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
+namada_ibc = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
+namada_token = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
+namada_parameters = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
+namada_proof_of_stake = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
+tendermint = "0.38.0"
+tendermint-config = "0.38.0"
+tendermint-rpc = { version = "0.38.0", features = ["http-client"] }
+tendermint-proto = "0.38.0"
 subtle-encoding = "0.5.1"
 bimap = { version = "0.6.3", features = ["serde"] }
 async-stream = "0.3.5"

--- a/chain/src/services/namada.rs
+++ b/chain/src/services/namada.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, Context};
 use futures::StreamExt;
-use namada_core::storage::{
+use namada_core::chain::{
     BlockHeight as NamadaSdkBlockHeight, Epoch as NamadaSdkEpoch,
 };
 use namada_sdk::address::{Address as NamadaSdkAddress, InternalAddress};
@@ -86,7 +86,7 @@ pub async fn query_balance(
 
             let token = NamadaSdkAddress::from(balance_change.token.clone());
 
-            let amount = rpc::get_token_balance(client, &token, &owner)
+            let amount = rpc::get_token_balance(client, &token, &owner, None)
                 .await
                 .unwrap_or_default();
 

--- a/parameters/src/services/namada.rs
+++ b/parameters/src/services/namada.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::Context;
-use namada_core::storage::Epoch as NamadaEpoch;
+use namada_core::chain::Epoch as NamadaEpoch;
 use namada_parameters::EpochDuration;
 use namada_sdk::address::Address as NamadaAddress;
 use namada_sdk::arith::checked;

--- a/pos/src/services/namada.rs
+++ b/pos/src/services/namada.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use futures::{StreamExt, TryStreamExt};
-use namada_core::storage::Epoch as NamadaSdkEpoch;
+use namada_core::chain::Epoch as NamadaSdkEpoch;
 use namada_sdk::rpc;
 use shared::block::Epoch;
 use shared::id::Id;

--- a/shared/src/ser.rs
+++ b/shared/src/ser.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 
 use namada_core::address::Address;
-use namada_core::masp::TxId;
+use namada_core::masp::MaspTxId;
 use namada_sdk::ibc::IbcMessage as NamadaIbcMessage;
 use namada_sdk::token::{
     Account as NamadaAccount, DenominatedAmount as NamadaDenominatedAmount,
@@ -72,7 +72,7 @@ pub struct TransparentTransfer {
     /// Targets of this transfer
     pub targets: AccountsMap,
     /// Hash of tx section that contains the MASP transaction
-    pub shielded_section_hash: Option<TxId>,
+    pub shielded_section_hash: Option<MaspTxId>,
 }
 
 impl From<NamadaTransfer> for TransparentTransfer {

--- a/shared/src/validator.rs
+++ b/shared/src/validator.rs
@@ -1,4 +1,4 @@
-use fake::faker::company::en::{CatchPhase, CompanyName};
+use fake::faker::company::en::{CatchPhrase, CompanyName};
 use fake::faker::internet::en::{DomainSuffix, SafeEmail, Username};
 use fake::Fake;
 use namada_proof_of_stake::types::ValidatorState as NamadaValidatorState;
@@ -77,7 +77,7 @@ impl Validator {
             ((0..100).fake::<u64>() as f64 / 100_f64).to_string();
         let commission = ((0..100).fake::<u64>() as f64 / 100_f64).to_string();
         let email = Some(SafeEmail().fake());
-        let description: Option<String> = CatchPhase().fake();
+        let description: Option<String> = CatchPhrase().fake();
         let name = Some(CompanyName().fake::<String>());
         let website: Option<String> = Some(format!(
             "{}.{}",


### PR DESCRIPTION
After upgrading housefire chain to v0.44.0, the `chain` service would no longer function, but after bumping the sdk version everything is running smoothly again.