### PR TITLE
Increase memory limit for dragonfly in docker-compose-db.yml

### DIFF
--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -19,7 +19,7 @@ services:
 
   dragonfly:
     image: docker.dragonflydb.io/dragonflydb/dragonfly
-    command: --logtostderr --cache_mode=true --port 6379 -dbnum 1 --maxmemory=2gb
+    command: --logtostderr --cache_mode=true --port 6379 -dbnum 1 --maxmemory=16gb
     ulimits:
       memlock: -1
     ports:

--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -19,7 +19,7 @@ services:
 
   dragonfly:
     image: docker.dragonflydb.io/dragonflydb/dragonfly
-    command: --logtostderr --cache_mode=true --port 6379 -dbnum 1 --maxmemory=16gb
+    command: --logtostderr --cache_mode=true --port 6379 -dbnum 1
     ulimits:
       memlock: -1
     ports:


### PR DESCRIPTION
Problem:
The dragonfly container exited.

Issue:
```
* For the available flags type dragonfly [--help | --helpfull]
* Documentation can be found at: https://www.dragonflydb.io/docs
W20241002 07:35:12.754663     1 dfly_main.cc:679] SWAP is enabled. Consider disabling it when running Dragonfly.
I20241002 07:35:12.754685     1 dfly_main.cc:703] Max memory limit is: 2.00GiB
W20241002 07:35:12.754709     1 dfly_main.cc:367] Weird error 1 switching to epoll
I20241002 07:35:12.833235     1 proactor_pool.cc:147] Running 48 io threads
E20241002 07:35:12.833262     1 dfly_main.cc:168] There are 48 threads, so 12.00GiB are required. Exiting...
```
Cause:
The service calculated the required memory and assessed the limit.

Fix:
Increase the memory limit.