### PR TITLE
add become_validator enum

### DIFF
--- a/orm/migrations/2024-06-09-102302_transactions/up.sql
+++ b/orm/migrations/2024-06-09-102302_transactions/up.sql
@@ -14,6 +14,7 @@ CREATE TYPE TRANSACTION_KIND AS ENUM (
     'change_metadata',
     'change_commission',
     'reveal_pk',
+    'become_validator',
     'unknown'
 );
 

--- a/orm/migrations/2024-06-12-140948_gas/up.sql
+++ b/orm/migrations/2024-06-12-140948_gas/up.sql
@@ -50,6 +50,9 @@ INSERT INTO gas (tx_kind, token, gas_limit)
 VALUES ('reveal_pk', 'native', 250_000);
 
 INSERT INTO gas (tx_kind, token, gas_limit)
+VALUES ('become_validator', 'native', 250_000);
+
+INSERT INTO gas (tx_kind, token, gas_limit)
 VALUES ('ibc_msg_transfer', 'native', 250_000);
 
 INSERT INTO gas (tx_kind, token, gas_limit)


### PR DESCRIPTION
Not sure if this is the right way to edit the sql files, feel free to close if not! But on housefire chain we were getting this error:
```
transactions-1  | 2024-10-16T20:38:04.833170Z  INFO transactions: Query block results...
transactions-1  | 2024-10-16T20:38:04.836087Z  INFO transactions: Deserialized 2 txs...
transactions-1  | 2024-10-16T20:38:04.837922Z ERROR shared::error: Database error reason=Failed to insert inner transactions in db
transactions-1  |
transactions-1  | Caused by:
transactions-1  |     invalid input value for enum transaction_kind: "become_validator"
```

Has been running fine after rebuilding with these changes.