### PR TITLE
feat: one native token constraint and namada bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,14 @@ axum-extra = { version = "0.9.3", features = ["query"] }
 chrono = { version = "0.4.30", features = ["serde"] }
 async-trait = "0.1.73"
 anyhow = "1.0.75"
-namada_core = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
-namada_sdk = { git = "https://github.com/anoma/namada", tag = "v0.44.0", default-features = false, features = ["std", "async-send", "download-params"] }
-namada_tx = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
-namada_governance = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
-namada_ibc = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
-namada_token = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
-namada_parameters = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
-namada_proof_of_stake = { git = "https://github.com/anoma/namada", tag = "v0.44.0" }
+namada_core = { git = "https://github.com/anoma/namada", tag = "v0.45.1" }
+namada_sdk = { git = "https://github.com/anoma/namada", tag = "v0.45.1", default-features = false, features = ["std", "async-send", "download-params"] }
+namada_tx = { git = "https://github.com/anoma/namada", tag = "v0.45.1" }
+namada_governance = { git = "https://github.com/anoma/namada", tag = "v0.45.1" }
+namada_ibc = { git = "https://github.com/anoma/namada", tag = "v0.45.1" }
+namada_token = { git = "https://github.com/anoma/namada", tag = "v0.45.1" }
+namada_parameters = { git = "https://github.com/anoma/namada", tag = "v0.45.1" }
+namada_proof_of_stake = { git = "https://github.com/anoma/namada", tag = "v0.45.1" }
 tendermint = "0.38.0"
 tendermint-config = "0.38.0"
 tendermint-rpc = { version = "0.38.0", features = ["http-client"] }

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,6 @@ At this point only by checking the state of the database. In the future we might
 
 For the API documentation, please refer to the [swagger.yml](../swagger.yml) file.
 We generate the client using [OpenApi generator](https://github.com/OpenAPITools/openapi-generator).
-You can find the published versions [here](https://www.npmjs.com/package/@anomaorg/namada-indexer-client).
+You can find the published versions [here](https://www.npmjs.com/package/@namada/indexer-client).
 
 Graphs/cards thanks to [excalidraw <3](docs_indexer_2024_09_20.excalidraw).

--- a/orm/migrations/2024-04-17-090406_tokens/down.sql
+++ b/orm/migrations/2024-04-17-090406_tokens/down.sql
@@ -1,4 +1,5 @@
 -- This file should undo anything in `up.sql`
+DROP INDEX one_native_token;
 
 DROP TABLE IF EXISTS ibc_token;
 DROP TABLE IF EXISTS token;

--- a/orm/migrations/2024-04-17-090406_tokens/up.sql
+++ b/orm/migrations/2024-04-17-090406_tokens/up.sql
@@ -12,3 +12,6 @@ CREATE TABLE ibc_token (
     ibc_trace VARCHAR NOT NULL,
     CONSTRAINT fk_ibc_token_token FOREIGN KEY(address) REFERENCES token(address) ON DELETE CASCADE
 );
+
+CREATE UNIQUE INDEX one_native_token ON token (token_type) 
+WHERE token_type = 'native';

--- a/swagger-codegen.json
+++ b/swagger-codegen.json
@@ -1,5 +1,5 @@
 {
-  "npmName": "@anomaorg/namada-indexer-client",
-  "npmVersion": "0.0.27"
+  "npmName": "@namada/indexer-client",
+  "npmVersion": "0.0.28"
 }
 

--- a/webserver/src/app.rs
+++ b/webserver/src/app.rs
@@ -134,7 +134,10 @@ impl ApplicationServer {
                 )
                 // Server sent events endpoints
                 .route("/chain/status", get(chain_handlers::chain_status))
-                .route("/metrics", get(|| async move { metric_handle.render() }))
+                .route(
+                    "/metrics",
+                    get(|| async move { metric_handle.render() }),
+                )
                 .with_state(common_state)
         };
 


### PR DESCRIPTION
Resolves [#136](https://github.com/anoma/namada-indexer/issues/136)

With this change indexer will throw an error if you try to insert native token(with different addresses) twice. This unfortunately means that you need to clear the DB if you restart chain with new genesis parameters.
@iskay @sirouk 

Also:
- bumps namada to 0.45.1
- changes indexer client org to namada to be consistent 
- adds workaround to set APR to 0 for epoch 0