### PR TITLE
fix: replace tally type from two thirds to two fifths

### DIFF
--- a/orm/migrations/2024-05-08-130928_governance_proposals/up.sql
+++ b/orm/migrations/2024-05-08-130928_governance_proposals/up.sql
@@ -1,6 +1,6 @@
 CREATE TYPE GOVERNANCE_KIND AS ENUM ('pgf_steward', 'pgf_funding', 'default', 'default_with_wasm');
 CREATE TYPE GOVERNANCE_RESULT AS ENUM ('passed', 'rejected', 'pending', 'unknown', 'voting_period');
-CREATE TYPE GOVERNANCE_TALLY_TYPE AS ENUM ('two_thirds', 'one_half_over_one_third', 'less_one_half_over_one_third_nay');
+CREATE TYPE GOVERNANCE_TALLY_TYPE AS ENUM ('two_fifths', 'one_half_over_one_third', 'less_one_half_over_one_third_nay');
 
 CREATE TABLE governance_proposals (
   id INT PRIMARY KEY,

--- a/orm/src/governance_proposal.rs
+++ b/orm/src/governance_proposal.rs
@@ -31,7 +31,7 @@ impl From<GovernanceProposalKind> for GovernanceProposalKindDb {
 #[derive(Debug, Clone, Serialize, Deserialize, diesel_derive_enum::DbEnum)]
 #[ExistingTypePath = "crate::schema::sql_types::GovernanceTallyType"]
 pub enum GovernanceProposalTallyTypeDb {
-    TwoThirds,
+    TwoFifths,
     OneHalfOverOneThird,
     LessOneHalfOverOneThirdNay,
 }
@@ -39,7 +39,7 @@ pub enum GovernanceProposalTallyTypeDb {
 impl From<TallyType> for GovernanceProposalTallyTypeDb {
     fn from(value: TallyType) -> Self {
         match value {
-            TallyType::TwoThirds => Self::TwoThirds,
+            TallyType::TwoFifths => Self::TwoFifths,
             TallyType::OneHalfOverOneThird => Self::OneHalfOverOneThird,
             TallyType::LessOneHalfOverOneThirdNay => {
                 Self::LessOneHalfOverOneThirdNay

--- a/swagger-codegen.json
+++ b/swagger-codegen.json
@@ -1,5 +1,5 @@
 {
   "npmName": "@namada/indexer-client",
-  "npmVersion": "0.0.29"
+  "npmVersion": "0.0.30"
 }
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -674,7 +674,7 @@ components:
           enum: [default, defaultWithWasm, pgfSteward, pgfFunding]
         tallyType:
           type: string
-          enum: [twoThirds, oneHalfOverOneThird, lessOneHalfOverOneThirdNay]
+          enum: [twoFifths, oneHalfOverOneThird, lessOneHalfOverOneThirdNay]
         data:
           type: string
         author:

--- a/webserver/src/response/governance.rs
+++ b/webserver/src/response/governance.rs
@@ -41,7 +41,7 @@ pub enum TallyType {
 impl Display for TallyType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TallyType::TwoFifths => write!(f, "two_thirds"),
+            TallyType::TwoFifths => write!(f, "two_fifths"),
             TallyType::OneHalfOverOneThird => {
                 write!(f, "one_half_over_one_third")
             }

--- a/webserver/src/response/governance.rs
+++ b/webserver/src/response/governance.rs
@@ -33,7 +33,7 @@ impl Display for ProposalType {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TallyType {
-    TwoThirds,
+    TwoFifths,
     OneHalfOverOneThird,
     LessOneHalfOverOneThirdNay,
 }
@@ -41,7 +41,7 @@ pub enum TallyType {
 impl Display for TallyType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TallyType::TwoThirds => write!(f, "two_thirds"),
+            TallyType::TwoFifths => write!(f, "two_thirds"),
             TallyType::OneHalfOverOneThird => {
                 write!(f, "one_half_over_one_third")
             }
@@ -172,8 +172,8 @@ impl Proposal {
                 }
             },
             tally_type: match value.tally_type {
-                GovernanceProposalTallyTypeDb::TwoThirds => {
-                    TallyType::TwoThirds
+                GovernanceProposalTallyTypeDb::TwoFifths => {
+                    TallyType::TwoFifths
                 }
                 GovernanceProposalTallyTypeDb::OneHalfOverOneThird => {
                     TallyType::OneHalfOverOneThird


### PR DESCRIPTION
Resolves [#147](https://github.com/anoma/namada-indexer/issues/147)

Merging this will introduce breaking change to both indexer db and namadillo integration, so we need to coordinate.

Related frontend [PR](https://github.com/anoma/namada-interface/pull/1252)