### PR TITLE
refactor: improve insert_balance_in_chunks -> insert_balances

### DIFF
--- a/chain/src/main.rs
+++ b/chain/src/main.rs
@@ -285,7 +285,7 @@ async fn crawling_fn(
                     ibc_tokens,
                 )?;
 
-                repository::balance::insert_balance_in_chunks(
+                repository::balance::insert_balances(
                     transaction_conn,
                     balances,
                 )?;
@@ -442,7 +442,7 @@ async fn try_initial_query(
                     "Inserting {} balances...",
                     balances.len()
                 );
-                repository::balance::insert_balance_in_chunks(
+                repository::balance::insert_balances(
                     transaction_conn,
                     balances,
                 )?;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -18,6 +18,7 @@ pub mod rewards;
 pub mod ser;
 pub mod token;
 pub mod transaction;
+pub mod tuple_len;
 pub mod unbond;
 pub mod utils;
 pub mod validator;

--- a/shared/src/tuple_len.rs
+++ b/shared/src/tuple_len.rs
@@ -1,0 +1,54 @@
+//
+// The TupleLen trait allows compile-time checking of the length of a tuple. This is useful for
+// statically determining the number of columns in a diesel schema table.
+//
+// Use it like this:
+//
+// let num_columns = orm::schema::(table_name)::all_columns.len();
+//
+// If you need to support tuples with more than 12 elements, you can add more type parameters to
+// the tuple! macro invocation at the bottom of this file.
+//
+
+pub trait TupleLen {
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+// Base case for empty tuple
+impl TupleLen for () {
+    fn len(&self) -> usize {
+        0
+    }
+}
+
+macro_rules! peel {
+    ($name:ident,) => {};
+    ($first:ident, $($rest:ident,)+) => {
+        tuple! { $($rest,)+ }
+    };
+}
+
+macro_rules! tuple {
+    () => {};
+    ( $($name:ident,)+ ) => {
+        impl<$($name),+> TupleLen for ($($name,)+) {
+            #[inline]
+            fn len(&self) -> usize {
+                count_idents!($($name),+)
+            }
+        }
+        peel! { $($name,)+ }
+    }
+}
+
+macro_rules! count_idents {
+    () => { 0 };
+    ($name:ident) => { 1 };
+    ($first:ident, $($rest:ident),+) => { 1 + count_idents!($($rest),+) };
+}
+
+// Initial invocation with maximum number of type parameters
+tuple! { L, K, J, I, H, G, F, E, D, C, B, A, }


### PR DESCRIPTION
This improves `insert_balance_in_chunks` to determine the column count from the diesel schema at compile-time, instead of making a separate query to `information_schema`. It also unifies the chunked and non-chunked functions into just one single (chunked) fn.