### PR TITLE
enhancement: webserver optional redis

### DIFF
--- a/shared/src/log_config.rs
+++ b/shared/src/log_config.rs
@@ -17,7 +17,7 @@ impl Display for LogFormat {
     }
 }
 
-#[derive(clap::Parser)]
+#[derive(clap::Parser, Clone)]
 pub struct LogConfig {
     #[command(flatten)]
     pub verbosity: Verbosity<InfoLevel>,

--- a/webserver/src/appstate.rs
+++ b/webserver/src/appstate.rs
@@ -7,11 +7,11 @@ use deadpool_redis::{Config, Connection, Pool as CachePool};
 #[derive(Clone)]
 pub struct AppState {
     db: DbPool,
-    cache: CachePool,
+    cache: Option<CachePool>,
 }
 
 impl AppState {
-    pub fn new(db_url: String, cache_url: String) -> Self {
+    pub fn new(db_url: String, cache_url: Option<String>) -> Self {
         let max_pool_size = env::var("DATABASE_POOL_SIZE")
             .unwrap_or_else(|_| 16.to_string())
             .parse::<usize>()
@@ -35,27 +35,34 @@ impl AppState {
             }
         };
 
-        let cache_pool = Config::from_url(cache_url)
-            .create_pool(Some(deadpool_redis::Runtime::Tokio1));
-        let cache_pool = match cache_pool {
-            Ok(pool) => pool,
-            Err(e) => {
-                tracing::info!("Error building redis pool: {}", e.to_string());
-                exit(1);
-            }
-        };
+        let cache = cache_url.map(|url| {
+            let cache_pool = Config::from_url(url)
+                .create_pool(Some(deadpool_redis::Runtime::Tokio1));
+            let cache_pool = match cache_pool {
+                Ok(pool) => pool,
+                Err(e) => {
+                    tracing::info!(
+                        "Error building redis pool: {}",
+                        e.to_string()
+                    );
+                    exit(1);
+                }
+            };
 
-        Self {
-            db: pool,
-            cache: cache_pool,
-        }
+            cache_pool
+        });
+
+        Self { db: pool, cache }
     }
 
     pub async fn get_db_connection(&self) -> Object {
         self.db.get().await.unwrap()
     }
 
-    pub async fn get_cache_connection(&self) -> Connection {
-        self.cache.get().await.unwrap()
+    pub async fn get_cache_connection(&self) -> Option<Connection> {
+        match &self.cache {
+            None => None,
+            Some(cache) => Some(cache.get().await.unwrap()),
+        }
     }
 }

--- a/webserver/src/config.rs
+++ b/webserver/src/config.rs
@@ -1,3 +1,5 @@
+use shared::log_config::LogConfig;
+
 #[derive(clap::ValueEnum, Clone, Debug, Copy)]
 pub enum CargoEnv {
     Development,
@@ -20,4 +22,7 @@ pub struct AppConfig {
 
     #[clap(long, env)]
     pub tendermint_url: String,
+
+    #[clap(flatten)]
+    pub log: LogConfig,
 }

--- a/webserver/src/config.rs
+++ b/webserver/src/config.rs
@@ -12,7 +12,7 @@ pub struct AppConfig {
     pub port: u16,
 
     #[clap(long, env)]
-    pub cache_url: String,
+    pub cache_url: Option<String>,
 
     #[clap(long, env)]
     pub database_url: String,

--- a/webserver/src/main.rs
+++ b/webserver/src/main.rs
@@ -7,9 +7,7 @@ use webserver::config::AppConfig;
 async fn main() -> anyhow::Result<()> {
     let config = AppConfig::parse();
 
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .init();
+    config.log.init();
 
     ApplicationServer::serve(config)
         .await


### PR DESCRIPTION
While deploying `webserver`, I found that it was requiring a redis cache to be deployed and configured in `CACHE_URL` even though it was not using it. I figured it might be good to make it optional; if you are deploying to a low-request-volume scenario (or for development) using a redis cache seems unnecessary to me.

Additionally, I added the shared `LogConfig` here to `webserver` so it will benefit from the `--log-format` and verbosity options like the other services.