### PR TITLE
fix webserver healthcheck issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ rust-project.json
 .vscode
 
 swagger-codegen.json
+
+# Ignore docker compose override files
+docker-compose.override*

--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -3,7 +3,7 @@ services:
     image: postgres:16-alpine
     command: ["postgres", "-c", "listen_addresses=0.0.0.0", "-c", "max_connections=200", "-p", "5433"]
     expose:
-      - "5433" # Publishes 5432 to other containers but NOT to host machine
+      - "5433"
     ports:
       - "5433:5433"
     environment:

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -19,7 +19,7 @@ FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 COPY --from=builder /app/target/release/webserver /app/webserver
 
-RUN apt-get update && apt-get install -y libpq5
+RUN apt-get update && apt-get install -y libpq5 curl
 
 WORKDIR /app
 


### PR DESCRIPTION
add curl to the webserver docker image so that the health check can be monitored correctly  
ignore docker-compose.override.* files from the repository for easier customization