### PR TITLE
feat: add block proposer to addresses_with_balance_change

### DIFF
--- a/shared/src/block.rs
+++ b/shared/src/block.rs
@@ -339,7 +339,7 @@ impl Block {
     // TODO: move this and process_inner_tx_for_balance to a separate module
     pub fn addresses_with_balance_change(
         &self,
-        native_token: Id,
+        native_token: &Id,
     ) -> HashSet<BalanceChange> {
         self.transactions
             .iter()
@@ -347,7 +347,7 @@ impl Block {
                 let mut balance_changes: Vec<BalanceChange> = inners_txs
                     .iter()
                     .filter_map(|tx| {
-                        self.process_inner_tx_for_balance(tx, &native_token)
+                        self.process_inner_tx_for_balance(tx, native_token)
                     })
                     .flatten()
                     .collect();


### PR DESCRIPTION
Per [this comment](https://github.com/anoma/namada-indexer/issues/199#issuecomment-2539378058) on https://github.com/anoma/namada-indexer/issues/199, block proposers also need balances fetched.

Figured this was an easy change -- @Fraccaman here's a PR implementing it, assuming this is the right fix here.