### PR TITLE
Change cargo versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.81-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.82-bookworm AS chef
 RUN apt-get update && apt-get install -y protobuf-compiler build-essential clang-tools-14
 
 FROM chef AS planner

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.82.0"
 components = ["rustc", "cargo", "rust-std", "rust-docs", "rls", "rust-src", "rust-analysis", "clippy", "rustfmt"]
 targets = []


### PR DESCRIPTION
Fix errors on `docker compose build` stage:
 ```
> [pos builder 5/5] RUN cargo build --release --bin pos:
0.496 info: syncing channel updates for '1.79.0-x86_64-unknown-linux-gnu' 0.910 info: latest update on 2024-06-13, rust version 1.79.0 (129f3b996 2024-06-10) 0.910 info: downloading component 'cargo'
1.716 info: downloading component 'clippy'
1.921 info: downloading component 'rls'
2.005 info: downloading component 'rust-analysis'
2.044 info: downloading component 'rust-docs'
2.991 info: downloading component 'rust-src'
3.143 info: downloading component 'rust-std'
4.207 info: downloading component 'rustc'
6.525 info: downloading component 'rustfmt'
6.636 info: installing component 'cargo'
7.526 info: installing component 'clippy'
7.859 info: installing component 'rls'
8.063 info: installing component 'rust-analysis'
8.175 info: installing component 'rust-docs'
10.59 info: installing component 'rust-src'
11.17 info: installing component 'rust-std'
13.86 info: installing component 'rustc'
20.24 info: installing component 'rustfmt'
21.56      Locking 11 packages to latest compatible versions
21.64     Updating chain v0.0.1 (/app/chain) -> v1.1.6
21.82     Updating governance v0.0.1 (/app/governance) -> v1.1.6
21.95     Updating orm v0.0.1 (/app/orm) -> v1.1.6
21.95     Updating parameters v0.0.1 (/app/parameters) -> v1.1.6
21.98     Updating pos v0.0.1 (/app/pos) -> v1.1.6
22.05     Updating rewards v0.0.1 (/app/rewards) -> v1.1.6
22.13     Updating seeder v0.0.1 (/app/seeder) -> v1.1.6
22.17     Updating shared v0.0.1 (/app/shared) -> v1.1.6
22.24     Updating test_helpers v0.0.1 (/app/test_helpers) -> v1.1.6
22.31     Updating transactions v0.0.1 (/app/transactions) -> v1.1.6
22.49     Updating webserver v0.0.1 (/app/webserver) -> v1.1.6
23.45 error: rustc 1.79.0 is not supported by the following packages:
23.45   pq-sys@0.7.0 requires rustc 1.82.0
23.45   pq-sys@0.7.0 requires rustc 1.82.0
23.45   pq-sys@0.7.0 requires rustc 1.82.0
23.45 Either upgrade rustc or select compatible dependency versions with
23.45 `cargo update <name>@<current-ver> --precise <compatible-ver>`
23.45 where `<compatible-ver>` is the latest version supporting rustc 1.79.0
23.45
------
failed to solve: process "/bin/sh -c cargo build --release --bin ${PACKAGE}" did not complete successfully: exit code: 101
```