### PR TITLE
client: specific compact mode

### DIFF
--- a/chain/src/main.rs
+++ b/chain/src/main.rs
@@ -37,6 +37,7 @@ use shared::token::Token;
 use shared::utils::BalanceChange;
 use shared::validator::ValidatorSet;
 use tendermint_rpc::HttpClient;
+use tendermint_rpc::client::CompatMode;
 use tendermint_rpc::endpoint::block::Response as TendermintBlockResponse;
 use tokio_retry::Retry;
 use tokio_retry::strategy::{ExponentialBackoff, jitter};
@@ -45,7 +46,11 @@ use tokio_retry::strategy::{ExponentialBackoff, jitter};
 async fn main() -> Result<(), MainError> {
     let config = AppConfig::parse();
 
-    let client = HttpClient::new(config.tendermint_url.as_str()).unwrap();
+    let client =
+        HttpClient::builder(config.tendermint_url.as_str().parse().unwrap())
+            .compat_mode(CompatMode::V0_37)
+            .build()
+            .unwrap();
 
     let mut checksums = Checksums::default();
     for code_path in Checksums::code_paths() {

--- a/governance/src/main.rs
+++ b/governance/src/main.rs
@@ -20,6 +20,7 @@ use shared::error::{AsDbError, AsRpcError, ContextDbInteractError, MainError};
 use shared::id::Id;
 use shared::pgf::{PaymentKind, PaymentRecurrence, PgfAction, PgfPayment};
 use tendermint_rpc::HttpClient;
+use tendermint_rpc::client::CompatMode;
 use tokio::sync::{Mutex, MutexGuard};
 use tokio::time::Instant;
 
@@ -31,8 +32,12 @@ async fn main() -> Result<(), MainError> {
 
     tracing::info!("version: {}", env!("VERGEN_GIT_SHA").to_string());
 
-    let client =
-        Arc::new(HttpClient::new(config.tendermint_url.as_str()).unwrap());
+    let client = Arc::new(
+        HttpClient::builder(config.tendermint_url.as_str().parse().unwrap())
+            .compat_mode(CompatMode::V0_37)
+            .build()
+            .unwrap(),
+    );
 
     let app_state = AppState::new(config.database_url).into_db_error()?;
 

--- a/parameters/src/main.rs
+++ b/parameters/src/main.rs
@@ -20,6 +20,7 @@ use shared::crawler;
 use shared::crawler_state::{CrawlerName, IntervalCrawlerState};
 use shared::error::{AsDbError, AsRpcError, ContextDbInteractError, MainError};
 use tendermint_rpc::HttpClient;
+use tendermint_rpc::client::CompatMode;
 use tokio::sync::{Mutex, MutexGuard};
 use tokio::time::Instant;
 
@@ -29,8 +30,12 @@ async fn main() -> Result<(), MainError> {
 
     config.log.init();
 
-    let client =
-        Arc::new(HttpClient::new(config.tendermint_url.as_str()).unwrap());
+    let client = Arc::new(
+        HttpClient::builder(config.tendermint_url.as_str().parse().unwrap())
+            .compat_mode(CompatMode::V0_37)
+            .build()
+            .unwrap(),
+    );
 
     let app_state = AppState::new(config.database_url).into_db_error()?;
     let conn = Arc::new(app_state.get_db_connection().await.into_db_error()?);

--- a/pos/src/main.rs
+++ b/pos/src/main.rs
@@ -16,6 +16,7 @@ use shared::crawler;
 use shared::crawler_state::{CrawlerName, EpochCrawlerState};
 use shared::error::{AsDbError, AsRpcError, ContextDbInteractError, MainError};
 use tendermint_rpc::HttpClient;
+use tendermint_rpc::client::CompatMode;
 
 #[tokio::main]
 async fn main() -> Result<(), MainError> {
@@ -23,8 +24,12 @@ async fn main() -> Result<(), MainError> {
 
     config.log.init();
 
-    let client =
-        Arc::new(HttpClient::new(config.tendermint_url.as_str()).unwrap());
+    let client = Arc::new(
+        HttpClient::builder(config.tendermint_url.as_str().parse().unwrap())
+            .compat_mode(CompatMode::V0_37)
+            .build()
+            .unwrap(),
+    );
 
     let app_state = AppState::new(config.database_url).into_db_error()?;
     let conn = Arc::new(app_state.get_db_connection().await.into_db_error()?);

--- a/rewards/src/main.rs
+++ b/rewards/src/main.rs
@@ -15,6 +15,7 @@ use shared::crawler;
 use shared::crawler_state::{CrawlerName, IntervalCrawlerState};
 use shared::error::{AsDbError, AsRpcError, ContextDbInteractError, MainError};
 use tendermint_rpc::HttpClient;
+use tendermint_rpc::client::CompatMode;
 use tokio::time::sleep;
 
 #[tokio::main]
@@ -25,8 +26,12 @@ async fn main() -> Result<(), MainError> {
 
     tracing::info!("version: {}", env!("VERGEN_GIT_SHA").to_string());
 
-    let client =
-        Arc::new(HttpClient::new(config.tendermint_url.as_str()).unwrap());
+    let client = Arc::new(
+        HttpClient::builder(config.tendermint_url.as_str().parse().unwrap())
+            .compat_mode(CompatMode::V0_37)
+            .build()
+            .unwrap(),
+    );
 
     let app_state = AppState::new(config.database_url).into_db_error()?;
 

--- a/transactions/run.sh
+++ b/transactions/run.sh
@@ -1,4 +1,4 @@
 . ../.env
 export TENDERMINT_URL
 export DATABASE_URL
-cargo run
+cargo run --release

--- a/transactions/src/main.rs
+++ b/transactions/src/main.rs
@@ -15,6 +15,7 @@ use shared::error::{AsDbError, AsRpcError, ContextDbInteractError, MainError};
 use shared::id::Id;
 use shared::transaction::IbcTokenFlow;
 use tendermint_rpc::HttpClient;
+use tendermint_rpc::client::CompatMode;
 use transactions::app_state::AppState;
 use transactions::config::AppConfig;
 use transactions::repository::{
@@ -31,8 +32,12 @@ async fn main() -> Result<(), MainError> {
 
     config.log.init();
 
-    let client =
-        Arc::new(HttpClient::new(config.tendermint_url.as_str()).unwrap());
+    let client = Arc::new(
+        HttpClient::builder(config.tendermint_url.as_str().parse().unwrap())
+            .compat_mode(CompatMode::V0_37)
+            .build()
+            .unwrap(),
+    );
 
     let mut checksums = Checksums::default();
     for code_path in Checksums::code_paths() {

--- a/webserver/src/app.rs
+++ b/webserver/src/app.rs
@@ -9,6 +9,7 @@ use axum::{BoxError, Json, Router};
 use axum_prometheus::PrometheusMetricLayer;
 use lazy_static::lazy_static;
 use namada_sdk::tendermint_rpc::HttpClient;
+use namada_sdk::tendermint_rpc::client::CompatMode;
 use serde_json::json;
 use tower::ServiceBuilder;
 use tower::buffer::BufferLayer;
@@ -42,7 +43,12 @@ impl ApplicationServer {
         let (prometheus_layer, metric_handle) = PrometheusMetricLayer::pair();
 
         let app_state = AppState::new(db_url, cache_url);
-        let client = HttpClient::new(config.tendermint_url.as_str()).unwrap();
+        let client = HttpClient::builder(
+            config.tendermint_url.as_str().parse().unwrap(),
+        )
+        .compat_mode(CompatMode::V0_37)
+        .build()
+        .unwrap();
 
         let routes = {
             let common_state =


### PR DESCRIPTION
`tendermint-rpc` upgraded to 0.38.0 as default, changing the structure of `vote` field in the block response