### PR TITLE
feat: add slash rates to params

### DIFF
--- a/orm/migrations/2025-02-25-085529_drop-gas/down.sql
+++ b/orm/migrations/2025-02-25-085529_drop-gas/down.sql
@@ -1,2 +1,7 @@
--- This file should undo anything in `up.sql`
-SELECT 1;
+CREATE TABLE gas (
+    id SERIAL PRIMARY KEY,
+    tx_kind TRANSACTION_KIND NOT NULL,
+    gas_limit INT NOT NULL
+);
+
+ALTER TABLE gas ADD UNIQUE (tx_kind);

--- a/orm/migrations/2025-02-28-114410_add_cubic_slashing_rates/down.sql
+++ b/orm/migrations/2025-02-28-114410_add_cubic_slashing_rates/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chain_parameters DROP COLUMN duplicate_vote_min_slash_rate;
+ALTER TABLE chain_parameters DROP COLUMN light_client_attack_min_slash_rate;

--- a/orm/migrations/2025-02-28-114410_add_cubic_slashing_rates/up.sql
+++ b/orm/migrations/2025-02-28-114410_add_cubic_slashing_rates/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE chain_parameters
+ADD COLUMN duplicate_vote_min_slash_rate DECIMAL NOT NULL DEFAULT 0;
+
+ALTER TABLE chain_parameters
+ADD COLUMN light_client_attack_min_slash_rate DECIMAL NOT NULL DEFAULT 0;

--- a/orm/src/parameters.rs
+++ b/orm/src/parameters.rs
@@ -1,7 +1,9 @@
+use std::str::FromStr;
+
+use bigdecimal::BigDecimal;
 use diesel::prelude::Insertable;
 use diesel::query_builder::AsChangeset;
 use diesel::{Queryable, Selectable};
-use serde::Serialize;
 use serde_json::Value as SerdeJSONValue;
 use shared::checksums::Checksums;
 use shared::genesis::Genesis;
@@ -9,7 +11,7 @@ use shared::parameters::{EpochSwitchBlocksDelay, Parameters};
 
 use crate::schema::chain_parameters;
 
-#[derive(Serialize, Insertable, AsChangeset, Clone)]
+#[derive(Insertable, AsChangeset, Clone)]
 #[diesel(table_name = chain_parameters)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ParametersInsertDb {
@@ -26,9 +28,11 @@ pub struct ParametersInsertDb {
     pub checksums: SerdeJSONValue,
     pub epoch_switch_blocks_delay: i32,
     pub cubic_slashing_window_length: i32,
+    pub duplicate_vote_min_slash_rate: BigDecimal,
+    pub light_client_attack_min_slash_rate: BigDecimal,
 }
 
-#[derive(Serialize, Queryable, Selectable, Clone)]
+#[derive(Queryable, Selectable, Clone)]
 #[diesel(table_name = chain_parameters)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ParametersDb {
@@ -46,6 +50,8 @@ pub struct ParametersDb {
     pub checksums: SerdeJSONValue,
     pub epoch_switch_blocks_delay: i32,
     pub cubic_slashing_window_length: i32,
+    pub duplicate_vote_min_slash_rate: BigDecimal,
+    pub light_client_attack_min_slash_rate: BigDecimal,
 }
 
 impl From<(Parameters, Genesis, Checksums, EpochSwitchBlocksDelay)>
@@ -76,6 +82,14 @@ impl From<(Parameters, Genesis, Checksums, EpochSwitchBlocksDelay)>
             cubic_slashing_window_length: parameters
                 .cubic_slashing_window_length
                 as i32,
+            duplicate_vote_min_slash_rate: BigDecimal::from_str(
+                &parameters.duplicate_vote_min_slash_rate,
+            )
+            .expect("Invalid duplicate_vote_min_slash_rate"),
+            light_client_attack_min_slash_rate: BigDecimal::from_str(
+                &parameters.light_client_attack_min_slash_rate,
+            )
+            .expect("Invalid light_client_attack_min_slash_rate"),
         }
     }
 }

--- a/orm/src/schema.rs
+++ b/orm/src/schema.rs
@@ -1,107 +1,55 @@
 // @generated automatically by Diesel CLI.
 
 pub mod sql_types {
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "crawler_name"))]
     pub struct CrawlerName;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "governance_kind"))]
     pub struct GovernanceKind;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "governance_result"))]
     pub struct GovernanceResult;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "governance_tally_type"))]
     pub struct GovernanceTallyType;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "history_kind"))]
     pub struct HistoryKind;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "ibc_status"))]
     pub struct IbcStatus;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "payment_kind"))]
     pub struct PaymentKind;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "payment_recurrence"))]
     pub struct PaymentRecurrence;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "token_type"))]
     pub struct TokenType;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "transaction_kind"))]
     pub struct TransactionKind;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "transaction_result"))]
     pub struct TransactionResult;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "validator_state"))]
     pub struct ValidatorState;
 
-    #[derive(
-        diesel::query_builder::QueryId,
-        std::fmt::Debug,
-        diesel::sql_types::SqlType,
-    )]
+    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "vote_kind"))]
     pub struct VoteKind;
 }
@@ -156,6 +104,8 @@ diesel::table! {
         epoch_switch_blocks_delay -> Int4,
         checksums -> Jsonb,
         cubic_slashing_window_length -> Int4,
+        duplicate_vote_min_slash_rate -> Numeric,
+        light_client_attack_min_slash_rate -> Numeric,
     }
 }
 

--- a/orm/src/schema.rs
+++ b/orm/src/schema.rs
@@ -1,55 +1,107 @@
 // @generated automatically by Diesel CLI.
 
 pub mod sql_types {
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "crawler_name"))]
     pub struct CrawlerName;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "governance_kind"))]
     pub struct GovernanceKind;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "governance_result"))]
     pub struct GovernanceResult;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "governance_tally_type"))]
     pub struct GovernanceTallyType;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "history_kind"))]
     pub struct HistoryKind;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "ibc_status"))]
     pub struct IbcStatus;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "payment_kind"))]
     pub struct PaymentKind;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "payment_recurrence"))]
     pub struct PaymentRecurrence;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "token_type"))]
     pub struct TokenType;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "transaction_kind"))]
     pub struct TransactionKind;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "transaction_result"))]
     pub struct TransactionResult;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "validator_state"))]
     pub struct ValidatorState;
 
-    #[derive(diesel::query_builder::QueryId, std::fmt::Debug, diesel::sql_types::SqlType)]
+    #[derive(
+        diesel::query_builder::QueryId,
+        std::fmt::Debug,
+        diesel::sql_types::SqlType,
+    )]
     #[diesel(postgres_type(name = "vote_kind"))]
     pub struct VoteKind;
 }

--- a/parameters/src/main.rs
+++ b/parameters/src/main.rs
@@ -19,8 +19,8 @@ use parameters::services::{
 use shared::crawler;
 use shared::crawler_state::{CrawlerName, IntervalCrawlerState};
 use shared::error::{AsDbError, AsRpcError, ContextDbInteractError, MainError};
-use tendermint_rpc::HttpClient;
 use tendermint_rpc::client::CompatMode;
+use tendermint_rpc::HttpClient;
 use tokio::sync::{Mutex, MutexGuard};
 use tokio::time::Instant;
 

--- a/parameters/src/main.rs
+++ b/parameters/src/main.rs
@@ -19,8 +19,8 @@ use parameters::services::{
 use shared::crawler;
 use shared::crawler_state::{CrawlerName, IntervalCrawlerState};
 use shared::error::{AsDbError, AsRpcError, ContextDbInteractError, MainError};
-use tendermint_rpc::client::CompatMode;
 use tendermint_rpc::HttpClient;
+use tendermint_rpc::client::CompatMode;
 use tokio::sync::{Mutex, MutexGuard};
 use tokio::time::Instant;
 

--- a/parameters/src/repository/parameters.rs
+++ b/parameters/src/repository/parameters.rs
@@ -21,6 +21,11 @@ pub fn upsert_chain_parameters(
                 .eq(excluded(chain_parameters::cubic_slashing_window_length)),
             chain_parameters::checksums
                 .eq(excluded(chain_parameters::checksums)),
+            chain_parameters::duplicate_vote_min_slash_rate
+                .eq(excluded(chain_parameters::duplicate_vote_min_slash_rate)),
+            chain_parameters::light_client_attack_min_slash_rate.eq(excluded(
+                chain_parameters::light_client_attack_min_slash_rate,
+            )),
         ))
         .execute(transaction_conn)
         .context("Failed to update chain_parameters state in db")?;

--- a/parameters/src/services/namada.rs
+++ b/parameters/src/services/namada.rs
@@ -113,6 +113,12 @@ pub async fn get_parameters(client: &HttpClient) -> anyhow::Result<Parameters> {
         native_token_address: native_token_address.to_string(),
         cubic_slashing_window_length: pos_parameters
             .cubic_slashing_window_length,
+        duplicate_vote_min_slash_rate: pos_parameters
+            .duplicate_vote_min_slash_rate
+            .to_string(),
+        light_client_attack_min_slash_rate: pos_parameters
+            .light_client_attack_min_slash_rate
+            .to_string(),
     })
 }
 

--- a/shared/src/parameters.rs
+++ b/shared/src/parameters.rs
@@ -9,6 +9,8 @@ pub struct Parameters {
     pub apr: String,
     pub native_token_address: String,
     pub cubic_slashing_window_length: u64,
+    pub duplicate_vote_min_slash_rate: String,
+    pub light_client_attack_min_slash_rate: String,
 }
 
 pub type EpochSwitchBlocksDelay = u32;

--- a/swagger.yml
+++ b/swagger.yml
@@ -562,16 +562,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RevealedPk"
-  /api/v1/gas:
-    get:
-      summary: Get the gas limit per tx kind.
-      responses:
-        "200":
-          description: Gas limit table
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GasLimitTable"
   /api/v1/gas-price:
     get:
       summary: Get all the gas prices
@@ -1171,35 +1161,6 @@ components:
       properties:
         publicKey:
           type: string
-    GasLimitTable:
-      type: array
-      items:
-        type: object
-        required: [gasLimit, txKind]
-        properties:
-          gasLimit:
-            type: number
-          txKind:
-            type: string
-            enum:
-              [
-                transparentTransfer,
-                shieldedTransfer,
-                shieldingTransfer,
-                unshieldingTransfer,
-                bond,
-                redelegation,
-                unbond,
-                withdraw,
-                claimRewards,
-                voteProposal,
-                initProposal,
-                changeMetadata,
-                changeCommission,
-                revealPk,
-                ibcMsgTransfer,
-                unknown,
-              ]
     GasPriceTable:
       type: array
       items:
@@ -1267,6 +1228,8 @@ components:
           checksums,
           epochSwitchBlocksDelay,
           cubicSlashingWindowLength,
+          duplicateVoteMinSlashRate,
+          lightClientAttackMinSlashRate,
         ]
       properties:
         unbondingLength:
@@ -1297,6 +1260,11 @@ components:
           type: string
         cubicSlashingWindowLength:
           type: string
+        duplicateVoteMinSlashRate:
+          type: string
+        lightClientAttackMinSlashRate:
+          type: string
+
     RpcUrl:
       type: object
       required: [url]

--- a/webserver/src/response/chain.rs
+++ b/webserver/src/response/chain.rs
@@ -19,6 +19,8 @@ pub struct Parameters {
     pub checksums: SerdeJSONValue,
     pub epoch_switch_blocks_delay: String,
     pub cubic_slashing_window_length: String,
+    pub duplicate_vote_min_slash_rate: String,
+    pub light_client_attack_min_slash_rate: String,
 }
 
 impl From<ParametersDb> for Parameters {
@@ -40,6 +42,12 @@ impl From<ParametersDb> for Parameters {
                 .to_string(),
             cubic_slashing_window_length: parameters
                 .cubic_slashing_window_length
+                .to_string(),
+            duplicate_vote_min_slash_rate: parameters
+                .duplicate_vote_min_slash_rate
+                .to_string(),
+            light_client_attack_min_slash_rate: parameters
+                .light_client_attack_min_slash_rate
                 .to_string(),
         }
     }


### PR DESCRIPTION
- pos slash rates
- recreating db on drop gas `down` migration so `diesel migration redo --all` works fine
- removed gas limit endpoint from `swagger.yml`