### PR TITLE
fix: remove the filter for claimed rewards in `find_rewards_by_delegator_and_validator_and_epoch`

### DIFF
--- a/webserver/src/repository/pos.rs
+++ b/webserver/src/repository/pos.rs
@@ -416,7 +416,6 @@ impl PosRepositoryTrait for PosRepository {
 
         conn.interact(move |conn| {
             pos_rewards::table
-                .filter(pos_rewards::claimed.eq(&false))
                 .filter(pos_rewards::dsl::owner.eq(delegator))
                 .filter(pos_rewards::dsl::validator_id.eq(validator_id))
                 .filter(pos_rewards::dsl::epoch.eq(epoch as i32))


### PR DESCRIPTION
This was removed [here](https://github.com/anoma/namada-indexer/commit/29bfa4d700925384a57a87e01559fb1b6a9e9562) when we were resolving the error where claimed balance wasn't being updated in Namadillo's `Unclaimed Staking Balance` panel (which was my fault from [here](https://github.com/anoma/namada-indexer/pull/204/files#diff-36fe991395e67a4696e36797bd05bc55bfb9078869486aa44e8dacab8461c394R378). 

For this endpoint, however, we don't want to filter the claimed rewards b/c we're querying to find the total rewards a user was paid per epoch. So we mustn't filter claimed rewards b/c otherwise each claimed epoch would give us `[]`

Here's what a successful query looks like:

```
$ curl -s https://indexer.namada.tududes.com:443/api/v1/pos/reward/tnam1qpumagd04vvc5c8552se32na7wrhvvganc0lj82r/tnam1q8lhvxys53dlc8wzlg7dyqf9avd0vff6wvav4amt/661
[{"minDenomAmount":"66940323","validator":{"address":"tnam1q8lhvxys53dlc8wzlg7dyqf9avd0vff6wvav4amt","votingPower":"10385382","maxCommission":"0.01","commission":"0.05","state":"consensus","name":"ValidityOps#1","email":"operations@validityops.com","website":"https://validityops.com","description":"🛡️Shields Up for Secure and Reliable Staking — Supporting the Namada Ecosystem!","discordHandle":null,"avatar":"https://avatars.githubusercontent.com/u/183962636?s=200&v=4","validatorId":"124","rank":null}}]
```

Here's what the current query looks like:

```
$ curl -s https://indexer.namada.tududes.com:443/api/v1/pos/reward/tnam1qr0evqhw9u0yqy9d5zmtq0q8ekckhe2vkqc3ky/tnam1q8lhvxys53dlc8wzlg7dyqf9avd0vff6wvav4amt/660
```
