### PR TITLE
Add cli flag to requery all (un)bonds on startup

### DIFF
--- a/chain/src/config.rs
+++ b/chain/src/config.rs
@@ -50,4 +50,13 @@ pub struct AppConfig {
 
     #[clap(flatten)]
     pub log: LogConfig,
+
+    #[clap(
+        short,
+        long,
+        env,
+        help = "Clear (un)bonds from DB and re-query them.",
+        default_value = "false"
+    )]
+    pub reindex_bonds: bool,
 }


### PR DESCRIPTION
To test `REINDEX_BONDS=true just run-chain` and check if ids in bonds and unbonds table changed